### PR TITLE
feat: add gradle publish plugin and required metadata to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'io.spring.javaformat' version '0.0.47'
+    id 'com.gradle.plugin-publish' version '1.3.1'
 }
 
 group = 'se.lfv.reqstool'
@@ -18,6 +19,9 @@ repositories {
 }
 
 gradlePlugin {
+    website = 'https://github.com/luftfartsverket/reqstool-java-gradle-plugin'
+    vcsUrl = 'https://github.com/luftfartsverket/reqstool-java-gradle-plugin.git'
+    
     plugins {
         reqstoolPlugin {
             id = 'se.lfv.reqstool'


### PR DESCRIPTION
Add Gradle Publish plugin to build.gradle to fix publish workflow.

Note: remember to update the website and vcsUrl under gradlePlugin in build.gradle when we migrate to reqstool organization.