### PR TITLE
build: SHA-pin GitHub Actions for supply-chain security

### DIFF
--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   check:
-    uses: reqstool/.github/.github/workflows/check-semantic-pr.yml@main
+    uses: reqstool/.github/.github/workflows/check-semantic-pr.yml@33502e31f66fb7e982f48f50e3c6c29b0410a017 # main 2026-03-07


### PR DESCRIPTION
## Summary

Pin GitHub Actions to exact commit SHAs instead of floating branch/tag references:

- `reqstool/.github/...@main` → SHA-pinned to current main commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)