### PR TITLE
build: derive version from Git tag via axion-release plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,17 @@ plugins {
     id 'maven-publish'
     id 'io.spring.javaformat' version '0.0.47'
     id 'com.gradle.plugin-publish' version '2.1.1'
+    id 'pl.allegro.tech.build.axion-release' version '1.18.0'
+}
+
+scmVersion {
+    tag {
+        prefix = ''
+    }
 }
 
 group = 'io.github.reqstool'
-version = '0.1.0'
+version = scmVersion.version
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ scmVersion {
     tag {
         prefix = ''
     }
+    versionCreator 'simple'
 }
 
 group = 'io.github.reqstool'


### PR DESCRIPTION
## Summary

Fixes the publish pipeline building `0.1.0` when releasing `0.1.1`.

- Adds `pl.allegro.tech.build.axion-release:1.18.0`
- Configures `tag.prefix = ''` to match existing plain-semver tags (`0.1.1`, not `v0.1.1`)
- Configures `versionCreator 'simple'` so snapshots are `x.y.z-SNAPSHOT` (not `x.y.z-branch-name`)
- Replaces `version = '0.1.0'` with `version = scmVersion.version`

**Version resolution behaviour:**
| Situation | Resolved version |
|---|---|
| On a tagged commit (release) | `0.1.1` (exact tag) |
| Any commit after tag | `0.1.2-SNAPSHOT` |

No CI workflow changes needed — the plugin reads from git state at build time.

## Test plan

- [x] `./gradlew currentVersion` shows `0.1.2-SNAPSHOT` (not `0.1.0`, not branch-suffixed)
- [x] `./gradlew test` passes
- [x] After merge and tagging `0.1.2`, the publish workflow resolves exactly `0.1.2`