### PR TITLE
refactor(ci): update centralized workflow references to common- prefix

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: reqstool/.github/.github/workflows/common-build-docs.yml@main

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   build:
-    uses: reqstool/.github/.github/workflows/build-docs.yml@main
+    uses: reqstool/.github/.github/workflows/common-build-docs.yml@main

--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   check:
-    uses: reqstool/.github/.github/workflows/check-semantic-pr.yml@e1d67194373e4da7ccfdf400f46201f18ca14f23 # main 2026-03-07
+    uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@e1d67194373e4da7ccfdf400f46201f18ca14f23 # main 2026-03-07

--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+
 jobs:
   check:
     uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@e1d67194373e4da7ccfdf400f46201f18ca14f23 # main 2026-03-07


### PR DESCRIPTION
## Summary

Follow-up to reqstool/.github#31 — `check-semantic-pr.yml` and/or `build-docs.yml` were renamed to `common-check-semantic-pr.yml` and `common-build-docs.yml` as part of flattening the centralized workflow directory structure (GitHub Actions does not support subdirectory paths for cross-repo reusable workflow references).

## Test plan

- [x] Merge reqstool/.github#31 first
- [x] Merge this PR
- [x] Verify CI passes on a subsequent PR in this repo