### PR TITLE
docs: document JUnit 5 parameterized test configuration for Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,34 @@ requirementsTool {
 }
 ```
 
+## JUnit 5 parameterized tests
+
+Gradle's JUnit XML reporter writes test case names using the parameterized test's display name.
+By default this is `[N] arguments` — a format that omits the method name.
+Reqstool cannot link these entries to `@SVCs`-annotated methods without the method name.
+
+Add this to your build to include the method name in every test case name, covering all test tasks (unit, integration, e2e):
+
+```groovy
+tasks.withType(Test).configureEach {
+    systemProperty 'junit.jupiter.params.displayname.default', '{displayName}[{index}]'
+}
+```
+
+Kotlin DSL:
+
+```kotlin
+tasks.withType<Test>().configureEach {
+    systemProperty("junit.jupiter.params.displayname.default", "{displayName}[{index}]")
+}
+```
+
+This produces names like `checkStatus(StatusType)[1]` instead of `[1] ACTIVE`, which reqstool can correctly attribute to the annotated method.
+
+> **Note:** Tests with an explicit `@ParameterizedTest(name = "{index} ...")` still omit the method name because the explicit value overrides the default. Either remove the custom `name` or change it to start with `{displayName}`: `@ParameterizedTest(name = "{displayName}[{index}] ...")`.
+
+Maven Surefire always embeds the method name regardless of display-name settings — no change needed for Maven projects.
+
 ## Task reference
 
 ### `assembleRequirements`

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -122,6 +122,44 @@ requirementsTool {
 }
 ----
 
+[[parameterized-tests]]
+== JUnit 5 parameterized tests
+
+Gradle's JUnit XML reporter writes test case names using the parameterized test's display name.
+By default this is `[N] arguments` -- a format that omits the method name.
+Reqstool cannot link these entries to `@SVCs`-annotated methods without the method name.
+
+Add the following to your build to make the method name part of every test case name, across
+all test tasks (unit, integration, e2e):
+
+[source,gradle]
+----
+tasks.withType(Test).configureEach {
+    systemProperty 'junit.jupiter.params.displayname.default', '{displayName}[{index}]'
+}
+----
+
+Kotlin DSL:
+
+[source,kotlin]
+----
+tasks.withType<Test>().configureEach {
+    systemProperty("junit.jupiter.params.displayname.default", "{displayName}[{index}]")
+}
+----
+
+This changes the default display name for every `@ParameterizedTest` that does not have an
+explicit `name =` attribute, producing names like `checkStatus(StatusType)[1]` instead of
+`[1] ACTIVE`.
+
+NOTE: Tests that use an explicit `@ParameterizedTest(name = "{index} ...")` still omit the
+method name because the explicit value overrides the default.
+Either remove the custom `name` or change it to begin with `{displayName}`:
+`@ParameterizedTest(name = "{displayName}[{index}] ...")`.
+
+Maven Surefire is unaffected -- it always embeds the method name regardless of display-name
+settings, so no configuration change is required for Maven projects.
+
 == Auto-wired task dependencies
 
 When the `java` plugin is applied, the plugin automatically wires:


### PR DESCRIPTION
## Summary

- Documents the Gradle `systemProperty` configuration that enables reqstool to track JUnit 5 parameterized test results per method
- Added to both `README.md` and `docs/modules/ROOT/pages/configuration.adoc`
- Covers Groovy and Kotlin DSL, all test task types (unit/integration/e2e), and the explicit-`name=` limitation

## Background

Gradle's JUnit XML reporter writes display-name-only test case names (e.g. `[1] ACTIVE`) that omit the method name. Reqstool uses the method name to link test results to `@SVCs`-annotated methods — without it, parameterized test results are skipped with a warning. Adding `systemProperty 'junit.jupiter.params.displayname.default', '{displayName}[{index}]'` to all `Test` tasks fixes this by producing names like `checkStatus(StatusType)[1]`.

Maven Surefire is unaffected — it always embeds the method name.

## Related

- reqstool-client PR: reqstool/reqstool-client#405 (parser fix + worst-status-wins)

## Test plan

- [ ] Add `tasks.withType(Test).configureEach { systemProperty 'junit.jupiter.params.displayname.default', '{displayName}[{index}]' }` to a Gradle project with `@ParameterizedTest` methods annotated with `@SVCs`
- [ ] Run `gradle build`
- [ ] Check `build/test-results/**/*.xml` — parameterized test case names should start with the method name (e.g. `checkStatus(StatusType)[1]`)
- [ ] Run `reqstool status` — parameterized test methods should now show as PASSED/FAILED rather than missing