### PR TITLE
chore(github-actions): pin reqstool/.github references to 1.0.0

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   build:
-    uses: reqstool/.github/.github/workflows/common-build-docs.yml@main
+    uses: reqstool/.github/.github/workflows/common-build-docs.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,17 +65,17 @@ jobs:
               build/generated/sources/annotationProcessor/java/test/resources/annotations.yml | grep -v "^#"
           } > build/reqstool/annotations.yml
       - name: Install reqstool
-        uses: reqstool/.github/.github/actions/install-reqstool@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        uses: reqstool/.github/.github/actions/install-reqstool@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
         with:
           reqstool-source: ${{ matrix.reqstool-source }}
       - name: Validate reqstool spec completeness
         # not yet available in the latest PyPI release
         if: matrix.reqstool-source == 'main'
-        uses: reqstool/.github/.github/actions/validate-reqstool@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        uses: reqstool/.github/.github/actions/validate-reqstool@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
       - name: Run reqstool status
-        uses: reqstool/.github/.github/actions/reqstool-status@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        uses: reqstool/.github/.github/actions/reqstool-status@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
         with:
           fail-if-incomplete: "true"
 
   validate-openspec:
-    uses: reqstool/.github/.github/workflows/common-validate-openspec.yml@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+    uses: reqstool/.github/.github/workflows/common-validate-openspec.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0

--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   check:
-    uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@main
+    uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   prepare:
-    uses: reqstool/.github/.github/workflows/common-release-prepare.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-prepare.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: read
     with:
@@ -67,7 +67,7 @@ jobs:
   tag:
     needs: [prepare, checks]
     if: ${{ !inputs.dry-run }}
-    uses: reqstool/.github/.github/workflows/common-release-tag.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-tag.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: write
     with:
@@ -80,7 +80,7 @@ jobs:
   # anything reaches the portal.
   publish-to-plugin-portal:
     needs: [prepare, tag]
-    uses: reqstool/.github/.github/workflows/java-publish-to-gradle.yml@main
+    uses: reqstool/.github/.github/workflows/java-publish-to-gradle.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: read
     secrets: inherit
@@ -106,7 +106,7 @@ jobs:
   promote:
     needs: [prepare, publish-to-plugin-portal]
     if: ${{ !inputs.dry-run && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-    uses: reqstool/.github/.github/workflows/common-release-promote.yml@main
+    uses: reqstool/.github/.github/workflows/common-release-promote.yml@ef815eae0bca7160cdc714126cac73f76d638b39 # 1.0.0
     permissions:
       contents: write
     with:


### PR DESCRIPTION
## Description

Implements [reqstool/.github#25](https://github.com/reqstool/.github/issues/25) for this repo.

Every `reqstool/.github` reference here now points at a commit SHA carrying a `# 1.0.0`
comment, replacing the mix of `@main` and `@<sha> # main <date>` that had accumulated.

`reqstool/.github` was tagged [1.0.0](https://github.com/reqstool/.github/releases/tag/1.0.0)
— its first ever tag — at the state verified end to end by this week's releases across all
nine publishing repos.

**Why this shape**, per the discussion on #25:

- `@main` is mutable, so CodeQL's `actions/unpinned-tag` flags it, and a change to
  `reqstool/.github` reaches this repo instantly with no review. We hit exactly that twice
  this week while fixing the PyPI publish path.
- `@1.0.0` alone would still be a mutable tag, so it would keep tripping the same rule.
- `@<sha> # 1.0.0` satisfies the pinning audits, and Renovate tracks the digest and rewrites
  the version comment alongside it — so the pin does not silently rot. That is the same
  treatment third-party actions already get in this org.

A companion PR narrows the `!/^reqstool\//` exclusion in `renovate.json5`, which is what
lets Renovate maintain these going forward. **That one merges after this**, so Renovate does
not try to pin `@main` refs mid-sweep.

## Checklist

- [x] I have reviewed and followed the contributing guidelines.
- [x] I have run a local build and made sure all tests pass.
- [x] I have signed off the DCO (`git commit -s`).
- [x] I have read the Code of Conduct and agree to abide by it.

## Test plan

Mechanical, generated by script and YAML-validated across every touched file. The refs all
resolve to the same tree they did before — `1.0.0` points at `ef815ea`, which is what `@main`
already resolved to when this was written, so no behaviour changes. CI on this PR exercises
the pinned refs directly.
